### PR TITLE
Add drag-and-drop file upload fragment with configurable limits

### DIFF
--- a/src/main/java/com/cmms10/plantMaster/controller/PlantMasterController.java
+++ b/src/main/java/com/cmms10/plantMaster/controller/PlantMasterController.java
@@ -43,6 +43,9 @@ public class PlantMasterController {
     @Value("${file.upload.max-file-size:10MB}")
     private String maxFileSize;
 
+    @Value("${file.upload.accept:*/*}")
+    private String fileAccept;
+
     /**
      * 설비 등록 화면
      * 
@@ -72,6 +75,7 @@ public class PlantMasterController {
         // 파일 업로드 설정 추가
         model.addAttribute("maxFileCount", maxFileCount);
         model.addAttribute("maxFileSize", maxFileSize);
+        model.addAttribute("fileAccept", fileAccept);
 
         return "plantMaster/plantMasterForm";
     }
@@ -105,6 +109,7 @@ public class PlantMasterController {
         // 파일 업로드 설정 추가
         model.addAttribute("maxFileCount", maxFileCount);
         model.addAttribute("maxFileSize", maxFileSize);
+        model.addAttribute("fileAccept", fileAccept);
 
         return "plantMaster/plantMasterForm";
     }

--- a/src/main/resources/templates/common/file/uploadFragment.html
+++ b/src/main/resources/templates/common/file/uploadFragment.html
@@ -1,17 +1,19 @@
 <!-- 파일 업로드 프래그먼트 -->
-<div th:fragment="fileUploadFragment(companyId, moduleName, fileGroupId, maxFileCount, maxFileSize)"
-    class="file-upload-component">
+<div th:fragment="fileUploadFragment(companyId, moduleName, fileGroupId, maxFileCount, maxTotalMb, accept)"
+    th:id="'fileUploadComponent_' + ${fileGroupId}"
+    class="file-upload-component"
+    th:data-max-files="${maxFileCount}"
+    th:data-max-total-mb="${maxTotalMb}"
+    th:data-accept="${accept}">
 
     <!-- Hidden Fields -->
     <input type="hidden" th:id="'companyId_' + ${fileGroupId}" th:value="${companyId}" />
     <input type="hidden" th:id="'moduleName_' + ${fileGroupId}" th:value="${moduleName}" />
     <input type="hidden" th:id="'fileGroupId_' + ${fileGroupId}" th:value="${fileGroupId != null ? fileGroupId : ''}" />
-    <input type="hidden" th:id="'maxFileCount_' + ${fileGroupId}" th:value="${maxFileCount}" />
-    <input type="hidden" th:id="'maxFileSize_' + ${fileGroupId}" th:value="${maxFileSize}" />
 
     <!-- File Upload Button -->
     <div style="margin-bottom: 15px;">
-        <input type="file" th:id="'fileInput_' + ${fileGroupId}" multiple style="display: none;" />
+        <input type="file" th:id="'fileInput_' + ${fileGroupId}" multiple style="display: none;" th:attr="accept=${accept}" />
         <button type="button"
             style="background-color: #007bff; color: white; padding: 8px 16px; border-radius: 4px; cursor: pointer; font-size: 0.8em; border: none;"
             th:data-file-group-id="${fileGroupId}" th:disabled="${fileGroupId == null || fileGroupId == ''}"
@@ -19,7 +21,7 @@
             파일 첨부
         </button>
         <span style="font-size: 0.8em; color: #666; margin-left: 10px;"
-            th:text="'최대 ' + ${maxFileCount} + '개 파일, 개별 파일 크기 ' + ${maxFileSize} + ' 이하'">
+            th:text="'최대 ' + ${maxFileCount} + '개 파일, 총 용량 ' + ${maxTotalMb} + 'MB 이하'">
             최대 파일 개수 및 크기 제한</span>
     </div>
 
@@ -64,6 +66,27 @@
 
             const moduleName = document.getElementById('moduleName_' + fileGroupId).value;
             const companyId = document.getElementById('companyId_' + fileGroupId).value;
+            const component = document.getElementById('fileUploadComponent_' + fileGroupId);
+            const maxFiles = parseInt(component.dataset.maxFiles || '0', 10);
+            const maxTotalMb = parseFloat(component.dataset.maxTotalMb || '0');
+
+            const fileList = document.getElementById('fileList_' + fileGroupId);
+            const existingFiles = fileList.querySelectorAll('[data-file-id]');
+
+            if (existingFiles.length + files.length > maxFiles) {
+                alert(`최대 ${maxFiles}개의 파일만 첨부할 수 있습니다.`);
+                return;
+            }
+
+            let currentSize = 0;
+            existingFiles.forEach(item => {
+                currentSize += parseInt(item.getAttribute('data-file-size') || '0', 10);
+            });
+            let newSize = Array.from(files).reduce((sum, f) => sum + f.size, 0);
+            if ((currentSize + newSize) > maxTotalMb * 1024 * 1024) {
+                alert(`총 파일 용량은 ${maxTotalMb}MB를 초과할 수 없습니다.`);
+                return;
+            }
 
             console.log('Uploading files:', {
                 fileGroupId: fileGroupId,
@@ -119,6 +142,7 @@
 
             const fileItem = document.createElement('div');
             fileItem.setAttribute('data-file-id', fileData.id);
+            fileItem.setAttribute('data-file-size', fileData.fileSize);
             fileItem.style.cssText = 'display: flex; justify-content: space-between; align-items: center; padding: 8px; border: 1px solid #ddd; border-radius: 4px; margin: 5px 0; background-color: white;';
 
             const fileSize = formatFileSize(fileData.fileSize);
@@ -216,9 +240,14 @@
         // 파일 입력 이벤트 설정
         function setupFileInput(fileGroupId) {
             const fileInput = document.getElementById('fileInput_' + fileGroupId);
+            const component = document.getElementById('fileUploadComponent_' + fileGroupId);
 
             if (!fileGroupId || fileGroupId.trim() === '') {
                 return;
+            }
+
+            if (component && component.dataset.accept) {
+                fileInput.setAttribute('accept', component.dataset.accept);
             }
 
             fileInput.addEventListener('change', function () {

--- a/src/main/resources/templates/common/file/vanillaFragment.html
+++ b/src/main/resources/templates/common/file/vanillaFragment.html
@@ -1,0 +1,159 @@
+<!-- Drag & Drop File Upload Fragment (Vanilla JS) -->
+<div th:fragment="vanillaFileUploadFragment(companyId, moduleName, fileGroupId, maxFileCount, maxTotalMb, accept)"
+     th:id="'vanillaUploadComponent_' + ${fileGroupId}"
+     class="vanilla-file-upload"
+     th:data-max-files="${maxFileCount}"
+     th:data-max-total-mb="${maxTotalMb}"
+     th:data-accept="${accept}">
+    <input type="hidden" th:id="'vanilla_companyId_' + ${fileGroupId}" th:value="${companyId}" />
+    <input type="hidden" th:id="'vanilla_moduleName_' + ${fileGroupId}" th:value="${moduleName}" />
+    <input type="hidden" th:id="'vanilla_fileGroupId_' + ${fileGroupId}" th:value="${fileGroupId != null ? fileGroupId : ''}" />
+
+    <div th:id="'vanilla_dropZone_' + ${fileGroupId}"
+         style="border:2px dashed #aaa; padding:20px; text-align:center; cursor:pointer;">
+        파일을 여기로 드래그하거나 클릭하여 업로드하세요.
+    </div>
+    <input type="file" th:id="'vanilla_fileInput_' + ${fileGroupId}" multiple style="display:none;" th:attr="accept=${accept}" />
+
+    <ul th:id="'vanilla_fileList_' + ${fileGroupId}" style="margin-top:10px; list-style:none; padding:0;"></ul>
+    <div th:id="'vanilla_noFiles_' + ${fileGroupId}"
+         style="text-align:center; color:#666; padding:20px; border:1px dashed #ccc; border-radius:4px; background-color:#f9f9f9; margin-top:10px;">
+        첨부된 파일이 없습니다.
+    </div>
+
+    <script th:inline="javascript">
+        (function(){
+            const component = document.getElementById('vanillaUploadComponent_' + [[${fileGroupId}]]);
+            const dropZone = document.getElementById('vanilla_dropZone_' + [[${fileGroupId}]]);
+            const fileInput = document.getElementById('vanilla_fileInput_' + [[${fileGroupId}]]);
+            const fileList = document.getElementById('vanilla_fileList_' + [[${fileGroupId}]]);
+            const noFiles = document.getElementById('vanilla_noFiles_' + [[${fileGroupId}]]);
+            const moduleName = [[${moduleName}]];
+            const companyId = [[${companyId}]];
+            const fileGroupId = [[${fileGroupId}]];
+
+            function formatFileSize(bytes){
+                if(bytes === 0) return '0 Bytes';
+                const k = 1024;
+                const sizes = ['Bytes','KB','MB','GB'];
+                const i = Math.floor(Math.log(bytes)/Math.log(k));
+                return (bytes/Math.pow(k,i)).toFixed(2) + ' ' + sizes[i];
+            }
+
+            function updateNoFiles(){
+                if(fileList.querySelectorAll('li[data-file-id]').length === 0){
+                    noFiles.style.display = 'block';
+                }else{
+                    noFiles.style.display = 'none';
+                }
+            }
+
+            function handleFiles(files){
+                if (!fileGroupId || fileGroupId.trim() === '') {
+                    alert('먼저 저장 후 파일을 첨부하세요.');
+                    return;
+                }
+                uploadFiles(Array.from(files));
+                fileInput.value = '';
+            }
+
+            function uploadFiles(files){
+                const maxFiles = parseInt(component.dataset.maxFiles || '0',10);
+                const maxTotalMb = parseFloat(component.dataset.maxTotalMb || '0');
+                const existingItems = fileList.querySelectorAll('li[data-file-id]');
+                if(existingItems.length + files.length > maxFiles){
+                    alert(`최대 ${maxFiles}개의 파일만 첨부할 수 있습니다.`);
+                    return;
+                }
+                let currentSize = Array.from(existingItems).reduce((sum,li)=>sum + parseInt(li.dataset.fileSize || '0',10),0);
+                let newSize = files.reduce((sum,f)=>sum + f.size,0);
+                if((currentSize + newSize) > maxTotalMb * 1024 * 1024){
+                    alert(`총 파일 용량은 ${maxTotalMb}MB를 초과할 수 없습니다.`);
+                    return;
+                }
+
+                files.forEach(file => {
+                    const formData = new FormData();
+                    formData.append('file', file);
+                    formData.append('fileGroupId', fileGroupId);
+                    formData.append('moduleName', moduleName);
+                    fetch('/file/upload', {method:'POST', body: formData})
+                        .then(res => res.json())
+                        .then(data => {
+                            if(data.success){
+                                addItem(data.fileData);
+                            }else{
+                                alert('파일 업로드 실패: ' + data.message);
+                            }
+                        })
+                        .catch(err => alert('파일 업로드 중 오류가 발생했습니다: ' + err.message));
+                });
+            }
+
+            function addItem(fileData){
+                const li = document.createElement('li');
+                li.dataset.fileId = fileData.id;
+                li.dataset.fileSize = fileData.fileSize;
+                li.style.margin = '5px 0';
+                li.style.display = 'flex';
+                li.style.justifyContent = 'space-between';
+                li.style.alignItems = 'center';
+                li.style.border = '1px solid #ddd';
+                li.style.padding = '8px';
+                li.style.borderRadius = '4px';
+                li.innerHTML = `<span>${fileData.originalFileName} (${formatFileSize(fileData.fileSize)})</span>`;
+                const delBtn = document.createElement('button');
+                delBtn.textContent = '삭제';
+                delBtn.style.backgroundColor = '#dc3545';
+                delBtn.style.color = '#fff';
+                delBtn.style.border = 'none';
+                delBtn.style.borderRadius = '4px';
+                delBtn.style.cursor = 'pointer';
+                delBtn.style.padding = '4px 8px';
+                delBtn.addEventListener('click', () => deleteFile(fileData.id));
+                li.appendChild(delBtn);
+                fileList.appendChild(li);
+                updateNoFiles();
+            }
+
+            function deleteFile(fileId){
+                fetch('/file/delete/' + fileId, {method:'DELETE'})
+                    .then(res => {
+                        if(res.ok){
+                            const li = fileList.querySelector('li[data-file-id="'+fileId+'"]');
+                            if(li) li.remove();
+                            updateNoFiles();
+                        }else{
+                            alert('파일 삭제 실패');
+                        }
+                    })
+                    .catch(()=>alert('파일 삭제 중 오류가 발생했습니다.'));
+            }
+
+            dropZone.addEventListener('click', () => fileInput.click());
+            dropZone.addEventListener('dragover', e => {e.preventDefault(); dropZone.style.backgroundColor = '#eef';});
+            dropZone.addEventListener('dragleave', () => {dropZone.style.backgroundColor = '';});
+            dropZone.addEventListener('drop', e => {
+                e.preventDefault();
+                dropZone.style.backgroundColor = '';
+                handleFiles(e.dataTransfer.files);
+            });
+            fileInput.addEventListener('change', () => handleFiles(fileInput.files));
+
+            if(fileGroupId && fileGroupId.trim() !== ''){
+                fetch('/file/list/' + fileGroupId)
+                    .then(res => res.json())
+                    .then(files => {
+                        if(files && files.length > 0){
+                            files.forEach(addItem);
+                        }
+                        updateNoFiles();
+                    })
+                    .catch(() => updateNoFiles());
+            }else{
+                updateNoFiles();
+            }
+        })();
+    </script>
+</div>
+

--- a/src/main/resources/templates/plantMaster/plantMasterForm.html
+++ b/src/main/resources/templates/plantMaster/plantMasterForm.html
@@ -207,7 +207,7 @@
                     <input type="hidden" id="fileGroupId" th:field="*{fileGroupId}" />
                     <!-- 파일 업로드 프래그먼트 포함 -->
                     <div
-                        th:replace="~{common/file/uploadFragment :: fileUploadFragment(${plantMaster.companyId}, 'plantmaster', ${plantMaster.fileGroupId}, ${maxFileCount}, ${maxFileSize})}">
+                        th:replace="~{common/file/uploadFragment :: fileUploadFragment(${plantMaster.companyId}, 'plantmaster', ${plantMaster.fileGroupId}, ${maxFileCount}, ${maxFileSize}, ${fileAccept})}">
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Allow PlantMaster forms to configure accepted file types
- Enforce max file count and total size via data attributes in upload fragment
- Introduce vanilla JS fragment with drag-and-drop file uploads

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b4b6ad44648323b289886fd5db90b7